### PR TITLE
feat(auth): Add login with phone number

### DIFF
--- a/features/auth/src/main/java/com/carissa/revibes/auth/data/AuthRepository.kt
+++ b/features/auth/src/main/java/com/carissa/revibes/auth/data/AuthRepository.kt
@@ -11,6 +11,10 @@ import org.koin.core.annotation.Single
 class AuthRepository(private val remoteApi: AuthRemoteApi) :
     BaseRepository(shouldKickWhenAuthFailed = false) {
 
+    suspend fun loginWithPhone(phone: String, password: String): LoginResult {
+        return execute { remoteApi.loginWithPhone(phone, password).toDomain() }
+    }
+
     suspend fun loginWithEmail(email: String, password: String): LoginResult {
         return execute { remoteApi.loginWithEmail(email, password).toDomain() }
     }

--- a/features/auth/src/main/java/com/carissa/revibes/auth/data/remote/AuthRemoteApi.kt
+++ b/features/auth/src/main/java/com/carissa/revibes/auth/data/remote/AuthRemoteApi.kt
@@ -19,10 +19,26 @@ interface AuthRemoteApi {
         @Field("password") password: String
     ): LoginResponse
 
+    @POST("auth/login/phone")
+    @FormUrlEncoded
+    suspend fun loginWithPhone(
+        @Field("phone") email: String,
+        @Field("password") password: String
+    ): LoginResponse
+
     @POST("auth/signup/email")
     @FormUrlEncoded
     suspend fun signUpWithEmail(
         @Field("email") email: String,
+        @Field("displayName") displayName: String,
+        @Field("phoneNumber") phoneNumber: String,
+        @Field("password") password: String
+    )
+
+    @POST("auth/signup/email")
+    @FormUrlEncoded
+    suspend fun signUpWithPhone(
+        @Field("phone") phone: String,
         @Field("displayName") displayName: String,
         @Field("phoneNumber") phoneNumber: String,
         @Field("password") password: String

--- a/features/auth/src/main/java/com/carissa/revibes/auth/presentation/mapper/UserDataMapper.kt
+++ b/features/auth/src/main/java/com/carissa/revibes/auth/presentation/mapper/UserDataMapper.kt
@@ -3,11 +3,24 @@ package com.carissa.revibes.auth.presentation.mapper
 import com.carissa.revibes.auth.domain.model.AuthUser
 import com.carissa.revibes.core.data.user.model.UserData
 
-internal fun AuthUser.toUserData(email: String): UserData {
+internal fun AuthUser.toUserDataWithEmail(email: String): UserData {
     return UserData(
         name = displayName,
         email = email,
         phoneNumber = "",
+        profilePictureUrl = "",
+        coins = 0,
+        role = role,
+        createdAt = createdAt,
+        lastClaimedDate = null
+    )
+}
+
+internal fun AuthUser.toUserDataWithPhone(phone: String): UserData {
+    return UserData(
+        name = displayName,
+        email = "",
+        phoneNumber = phone,
         profilePictureUrl = "",
         coins = 0,
         role = role,

--- a/features/auth/src/main/java/com/carissa/revibes/auth/presentation/screen/login/LoginScreen.kt
+++ b/features/auth/src/main/java/com/carissa/revibes/auth/presentation/screen/login/LoginScreen.kt
@@ -6,10 +6,13 @@ package com.carissa.revibes.auth.presentation.screen.login
 
 import android.widget.Toast
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -29,6 +32,9 @@ import com.carissa.revibes.core.presentation.compose.auth.AuthActionButton
 import com.carissa.revibes.core.presentation.compose.auth.AuthNavigationRow
 import com.carissa.revibes.core.presentation.compose.auth.EmailField
 import com.carissa.revibes.core.presentation.compose.auth.PasswordField
+import com.carissa.revibes.core.presentation.compose.auth.PhoneField
+import com.carissa.revibes.core.presentation.compose.components.StateSwitcherAnimator
+import com.carissa.revibes.core.presentation.compose.components.TabButton
 import com.carissa.revibes.core.presentation.compose.components.Text
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.generated.auth.destinations.LoginScreenDestination
@@ -97,14 +103,61 @@ private fun LoginScreenContent(
                     .padding(bottom = 32.dp)
             )
 
-            EmailField(
-                value = uiState.email,
-                onValueChange = { eventReceiver.onEvent(LoginScreenUiEvent.EmailChanged(it)) },
-                label = stringResource(R.string.label_enter_email),
-                isEnabled = !uiState.isLoading,
-                errorText = uiState.emailError
+            Text(
+                text = stringResource(R.string.label_login_with),
+                style = RevibesTheme.typography.h4,
+                modifier = Modifier.padding(bottom = 16.dp),
+                textAlign = TextAlign.Center,
+                color = RevibesTheme.colors.primary,
             )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                TabButton(
+                    "Email",
+                    uiState.loginType == LoginScreenUiState.Type.EMAIL,
+                    modifier = Modifier.weight(1f),
+                    onClick = {
+                        eventReceiver.onEvent(
+                            LoginScreenUiEvent.ChangeLoginType(LoginScreenUiState.Type.EMAIL)
+                        )
+                    }
+                )
+                TabButton(
+                    "Phone Number",
+                    uiState.loginType == LoginScreenUiState.Type.PHONE_NUMBER,
+                    modifier = Modifier.weight(1f),
+                    onClick = {
+                        eventReceiver.onEvent(
+                            LoginScreenUiEvent.ChangeLoginType(LoginScreenUiState.Type.PHONE_NUMBER)
+                        )
+                    }
+                )
+            }
 
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 16.dp),
+                color = RevibesTheme.colors.primary
+            )
+            StateSwitcherAnimator(
+                uiState.loginType
+            ) { type ->
+                when (uiState.loginType) {
+                    LoginScreenUiState.Type.EMAIL -> EmailField(
+                        value = uiState.userName,
+                        onValueChange = { eventReceiver.onEvent(LoginScreenUiEvent.EmailChanged(it)) },
+                        label = stringResource(R.string.label_enter_email),
+                        isEnabled = !uiState.isLoading,
+                        errorText = uiState.emailError
+                    )
+
+                    LoginScreenUiState.Type.PHONE_NUMBER -> PhoneField(
+                        value = uiState.userName,
+                        onValueChange = { eventReceiver.onEvent(LoginScreenUiEvent.EmailChanged(it)) },
+                        label = stringResource(R.string.label_enter_phone),
+                        isEnabled = !uiState.isLoading,
+                        errorText = uiState.phoneError
+                    )
+                }
+            }
             PasswordField(
                 value = uiState.password,
                 onValueChange = { eventReceiver.onEvent(LoginScreenUiEvent.PasswordChanged(it)) },

--- a/features/auth/src/main/java/com/carissa/revibes/auth/presentation/screen/login/handler/LoginSubmitHandler.kt
+++ b/features/auth/src/main/java/com/carissa/revibes/auth/presentation/screen/login/handler/LoginSubmitHandler.kt
@@ -12,15 +12,16 @@ class LoginSubmitHandler(
     private val doLoginUseCase: DoLoginUseCase
 ) {
     suspend fun doLogin(
+        type: LoginScreenUiState.Type,
         eventReceiver: EventReceiver<LoginScreenUiEvent>,
         syntax: Syntax<LoginScreenUiState, LoginScreenUiEvent>,
     ) {
         syntax.reduce {
             this.state.copy(isLoading = true)
         }
-        val email = syntax.state.email.text.trim()
+        val userName = syntax.state.userName.text.trim()
         val password = syntax.state.password.text.trim()
-        val userData = doLoginUseCase(email, password)
+        val userData = doLoginUseCase(type == LoginScreenUiState.Type.PHONE_NUMBER, userName, password)
         if (userData.role == "admin") {
             eventReceiver.onEvent(LoginScreenUiEvent.NavigateToAdminHome)
         } else {

--- a/features/auth/src/main/res/values/strings.xml
+++ b/features/auth/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="label_welcome">WELCOME</string>
     <string name="label_welcome_back">WELCOME BACK</string>
+    <string name="label_login_with">Login using</string>
     <string name="label_to">TO</string>
     <string name="label_enter_full_name">Enter Your Full Name</string>
     <string name="label_enter_email">Enter Your Email</string>

--- a/features/drop-off/src/main/java/com/carissa/revibes/drop_off/presentation/screen/DropOffScreen.kt
+++ b/features/drop-off/src/main/java/com/carissa/revibes/drop_off/presentation/screen/DropOffScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -592,7 +592,7 @@ private fun ItemSection(
                             },
                             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
                             modifier = Modifier
-                                .menuAnchor(type = MenuAnchorType.PrimaryEditable, enabled = true)
+                                .menuAnchor(type = ExposedDropdownMenuAnchorType.PrimaryEditable, enabled = true)
                                 .fillMaxWidth(),
                             colors = OutlinedTextFieldDefaults.colors().copy(
                                 focusedContainerColor = DropOffTextFieldBg,
@@ -644,7 +644,7 @@ private fun ItemSection(
                             },
                             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = weightExpanded) },
                             modifier = Modifier
-                                .menuAnchor(type = MenuAnchorType.PrimaryEditable, enabled = true)
+                                .menuAnchor(type = ExposedDropdownMenuAnchorType.PrimaryEditable, enabled = true)
                                 .fillMaxWidth(),
                             colors = OutlinedTextFieldDefaults.colors().copy(
                                 focusedContainerColor = DropOffTextFieldBg,

--- a/features/manage-users/src/main/java/com/carissa/revibes/manage_users/presentation/screen/AddUserScreen.kt
+++ b/features/manage-users/src/main/java/com/carissa/revibes/manage_users/presentation/screen/AddUserScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
@@ -173,7 +173,7 @@ private fun AddUserScreenContent(
                     onValueChange = {},
                     modifier = Modifier
                         .fillMaxWidth()
-                        .menuAnchor(MenuAnchorType.PrimaryNotEditable, true),
+                        .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable, true),
                     readOnly = true,
                     label = {
                         Text(

--- a/features/manage-voucher/src/main/java/com/carissa/revibes/manage_voucher/presentation/component/VoucherItem.kt
+++ b/features/manage-voucher/src/main/java/com/carissa/revibes/manage_voucher/presentation/component/VoucherItem.kt
@@ -269,7 +269,7 @@ fun VoucherItem(
                                 VoucherDomain.VoucherType.PERCENT_OFF -> "${voucher.value.amount.toInt()}%"
                                 VoucherDomain.VoucherType.FIXED_AMOUNT -> {
                                     val formatter =
-                                        NumberFormat.getCurrencyInstance(Locale("id", "ID"))
+                                        NumberFormat.getCurrencyInstance(Locale.forLanguageTag("id-ID"))
                                     formatter.format(voucher.value.amount)
                                 }
                             },

--- a/features/manage-voucher/src/main/java/com/carissa/revibes/manage_voucher/presentation/screen/AddVoucherScreen.kt
+++ b/features/manage-voucher/src/main/java/com/carissa/revibes/manage_voucher/presentation/screen/AddVoucherScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
@@ -292,7 +293,10 @@ private fun AddVoucherContent(
                                 label = { Text("Discount Type") },
                                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = typeExpanded) },
                                 modifier = Modifier
-                                    .menuAnchor()
+                                    .menuAnchor(
+                                        type = ExposedDropdownMenuAnchorType.PrimaryNotEditable,
+                                        enabled = true
+                                    )
                                     .fillMaxWidth(),
                                 shape = RoundedCornerShape(12.dp)
                             )


### PR DESCRIPTION
This commit introduces the functionality for users to log in using their phone number in addition to their email address.

Key changes include:
- Added a tabbed interface on the login screen to switch between email and phone number login methods.
- Implemented the necessary UI components, view model logic, and use cases to handle phone number authentication.
- Updated the `DoLoginUseCase` to differentiate between email and phone login and call the appropriate repository method.
- Introduced `PhoneValidator` for input validation.
- Renamed `email` to `userName` in `LoginScreenUiState` to accommodate both login types.
- Fixed `MenuAnchorType` deprecation by migrating to `ExposedDropdownMenuAnchorType`.
- Corrected the `Locale` instantiation for currency formatting from `("id", "ID")` to `Locale.forLanguageTag("id-ID")`.